### PR TITLE
rework: pagination previous and next page

### DIFF
--- a/src/main/java/com/github/syr0ws/fastinventory/api/config/PaginationConfig.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/api/config/PaginationConfig.java
@@ -1,6 +1,7 @@
 package com.github.syr0ws.fastinventory.api.config;
 
 import java.util.List;
+import java.util.Set;
 
 public interface PaginationConfig {
 
@@ -9,4 +10,12 @@ public interface PaginationConfig {
     List<Integer> getSlots();
 
     InventoryItemConfig getItem();
+
+    InventoryItemConfig getPreviousPageItem();
+
+    InventoryItemConfig getNextPageItem();
+
+    Set<Integer> getPreviousPageItemSlots();
+
+    Set<Integer> getNextPageItemSlots();
 }

--- a/src/main/java/com/github/syr0ws/fastinventory/api/pagination/PaginationModel.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/api/pagination/PaginationModel.java
@@ -27,6 +27,10 @@ public interface PaginationModel<T> {
 
     int getLastPage();
 
+    int getPreviousPage();
+
+    int getNextPage();
+
     boolean hasPreviousPage();
 
     boolean hasNextPage();

--- a/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/CommonPlaceholder.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/CommonPlaceholder.java
@@ -1,0 +1,31 @@
+package com.github.syr0ws.fastinventory.common.placeholder;
+
+import com.github.syr0ws.fastinventory.api.placeholder.Placeholder;
+import com.github.syr0ws.fastinventory.common.placeholder.inventory.InventorySizePlaceholder;
+import com.github.syr0ws.fastinventory.common.placeholder.inventory.InventoryTypePlaceholder;
+import com.github.syr0ws.fastinventory.common.placeholder.item.ItemSlotPlaceholder;
+import com.github.syr0ws.fastinventory.common.placeholder.pagination.CurrentPagePlaceholder;
+import com.github.syr0ws.fastinventory.common.placeholder.pagination.TotalPagesPlaceholder;
+import com.github.syr0ws.fastinventory.common.placeholder.player.PlayerNamePlaceholder;
+import com.github.syr0ws.fastinventory.common.placeholder.player.PlayerUUIDPlaceholder;
+
+public enum CommonPlaceholder {
+
+    INVENTORY_SIZE(new InventorySizePlaceholder()),
+    INVENTORY_TYPE(new InventoryTypePlaceholder()),
+    ITEM_SLOT(new ItemSlotPlaceholder()),
+    PLAYER_NAME(new PlayerNamePlaceholder()),
+    PLAYER_UUID(new PlayerUUIDPlaceholder()),
+    CURRENT_PAGE(new CurrentPagePlaceholder()),
+    TOTAL_PAGES(new TotalPagesPlaceholder());
+
+    private final Placeholder placeholder;
+
+    CommonPlaceholder(Placeholder placeholder) {
+        this.placeholder = placeholder;
+    }
+
+    public Placeholder getPlaceholder() {
+        return this.placeholder;
+    }
+}

--- a/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/CommonPlaceholder.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/CommonPlaceholder.java
@@ -5,6 +5,8 @@ import com.github.syr0ws.fastinventory.common.placeholder.inventory.InventorySiz
 import com.github.syr0ws.fastinventory.common.placeholder.inventory.InventoryTypePlaceholder;
 import com.github.syr0ws.fastinventory.common.placeholder.item.ItemSlotPlaceholder;
 import com.github.syr0ws.fastinventory.common.placeholder.pagination.CurrentPagePlaceholder;
+import com.github.syr0ws.fastinventory.common.placeholder.pagination.NextPagePlaceholder;
+import com.github.syr0ws.fastinventory.common.placeholder.pagination.PreviousPagePlaceholder;
 import com.github.syr0ws.fastinventory.common.placeholder.pagination.TotalPagesPlaceholder;
 import com.github.syr0ws.fastinventory.common.placeholder.player.PlayerNamePlaceholder;
 import com.github.syr0ws.fastinventory.common.placeholder.player.PlayerUUIDPlaceholder;
@@ -17,7 +19,9 @@ public enum CommonPlaceholder {
     PLAYER_NAME(new PlayerNamePlaceholder()),
     PLAYER_UUID(new PlayerUUIDPlaceholder()),
     CURRENT_PAGE(new CurrentPagePlaceholder()),
-    TOTAL_PAGES(new TotalPagesPlaceholder());
+    TOTAL_PAGES(new TotalPagesPlaceholder()),
+    PREVIOUS_PAGE(new PreviousPagePlaceholder()),
+    NEXT_PAGE(new NextPagePlaceholder());
 
     private final Placeholder placeholder;
 

--- a/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/inventory/InventorySizePlaceholder.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/inventory/InventorySizePlaceholder.java
@@ -1,4 +1,4 @@
-package com.github.syr0ws.fastinventory.common.placeholder;
+package com.github.syr0ws.fastinventory.common.placeholder.inventory;
 
 import com.github.syr0ws.fastinventory.api.FastInventory;
 import com.github.syr0ws.fastinventory.api.placeholder.Placeholder;

--- a/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/inventory/InventoryTypePlaceholder.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/inventory/InventoryTypePlaceholder.java
@@ -1,4 +1,4 @@
-package com.github.syr0ws.fastinventory.common.placeholder;
+package com.github.syr0ws.fastinventory.common.placeholder.inventory;
 
 import com.github.syr0ws.fastinventory.api.FastInventory;
 import com.github.syr0ws.fastinventory.api.placeholder.Placeholder;

--- a/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/item/ItemSlotPlaceholder.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/item/ItemSlotPlaceholder.java
@@ -1,4 +1,4 @@
-package com.github.syr0ws.fastinventory.common.placeholder;
+package com.github.syr0ws.fastinventory.common.placeholder.item;
 
 import com.github.syr0ws.fastinventory.api.placeholder.Placeholder;
 import com.github.syr0ws.fastinventory.api.util.Context;

--- a/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/pagination/CurrentPagePlaceholder.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/pagination/CurrentPagePlaceholder.java
@@ -1,13 +1,9 @@
 package com.github.syr0ws.fastinventory.common.placeholder.pagination;
 
-import com.github.syr0ws.fastinventory.api.FastInventory;
-import com.github.syr0ws.fastinventory.api.pagination.Pagination;
 import com.github.syr0ws.fastinventory.api.pagination.PaginationModel;
-import com.github.syr0ws.fastinventory.api.placeholder.Placeholder;
 import com.github.syr0ws.fastinventory.api.util.Context;
-import com.github.syr0ws.fastinventory.common.CommonContextKey;
 
-public class CurrentPagePlaceholder implements Placeholder {
+public class CurrentPagePlaceholder extends PaginationPlaceholder {
 
     @Override
     public String getName() {
@@ -16,20 +12,7 @@ public class CurrentPagePlaceholder implements Placeholder {
 
     @Override
     public String getValue(Context context) {
-
-        FastInventory inventory = context.getData(CommonContextKey.INVENTORY.name(), FastInventory.class);
-        String paginationId = context.getData(CommonContextKey.PAGINATION_ID.name(), String.class);
-
-        Pagination<?> pagination = inventory.getPagination(paginationId)
-                .orElseThrow(() -> new IllegalStateException(String.format("No pagination with id %s found", paginationId)));
-
-        PaginationModel<?> model = pagination.getModel();
-
+        PaginationModel<?> model = super.getPaginationModel(context);
         return Integer.toString(model.getCurrentPage());
-    }
-
-    @Override
-    public boolean accept(Context context) {
-        return context.hasData(CommonContextKey.PAGINATION_ID.name());
     }
 }

--- a/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/pagination/CurrentPagePlaceholder.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/pagination/CurrentPagePlaceholder.java
@@ -1,0 +1,35 @@
+package com.github.syr0ws.fastinventory.common.placeholder.pagination;
+
+import com.github.syr0ws.fastinventory.api.FastInventory;
+import com.github.syr0ws.fastinventory.api.pagination.Pagination;
+import com.github.syr0ws.fastinventory.api.pagination.PaginationModel;
+import com.github.syr0ws.fastinventory.api.placeholder.Placeholder;
+import com.github.syr0ws.fastinventory.api.util.Context;
+import com.github.syr0ws.fastinventory.common.CommonContextKey;
+
+public class CurrentPagePlaceholder implements Placeholder {
+
+    @Override
+    public String getName() {
+        return "%current_page%";
+    }
+
+    @Override
+    public String getValue(Context context) {
+
+        FastInventory inventory = context.getData(CommonContextKey.INVENTORY.name(), FastInventory.class);
+        String paginationId = context.getData(CommonContextKey.PAGINATION_ID.name(), String.class);
+
+        Pagination<?> pagination = inventory.getPagination(paginationId)
+                .orElseThrow(() -> new IllegalStateException(String.format("No pagination with id %s found", paginationId)));
+
+        PaginationModel<?> model = pagination.getModel();
+
+        return Integer.toString(model.getCurrentPage());
+    }
+
+    @Override
+    public boolean accept(Context context) {
+        return context.hasData(CommonContextKey.PAGINATION_ID.name());
+    }
+}

--- a/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/pagination/NextPagePlaceholder.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/pagination/NextPagePlaceholder.java
@@ -1,0 +1,18 @@
+package com.github.syr0ws.fastinventory.common.placeholder.pagination;
+
+import com.github.syr0ws.fastinventory.api.pagination.PaginationModel;
+import com.github.syr0ws.fastinventory.api.util.Context;
+
+public class NextPagePlaceholder extends PaginationPlaceholder {
+
+    @Override
+    public String getName() {
+        return "%next_page%";
+    }
+
+    @Override
+    public String getValue(Context context) {
+        PaginationModel<?> model = super.getPaginationModel(context);
+        return Integer.toString(model.getNextPage());
+    }
+}

--- a/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/pagination/PaginationPlaceholder.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/pagination/PaginationPlaceholder.java
@@ -1,0 +1,27 @@
+package com.github.syr0ws.fastinventory.common.placeholder.pagination;
+
+import com.github.syr0ws.fastinventory.api.FastInventory;
+import com.github.syr0ws.fastinventory.api.pagination.Pagination;
+import com.github.syr0ws.fastinventory.api.pagination.PaginationModel;
+import com.github.syr0ws.fastinventory.api.placeholder.Placeholder;
+import com.github.syr0ws.fastinventory.api.util.Context;
+import com.github.syr0ws.fastinventory.common.CommonContextKey;
+
+public abstract class PaginationPlaceholder implements Placeholder {
+
+    protected PaginationModel<?> getPaginationModel(Context context) {
+
+        FastInventory inventory = context.getData(CommonContextKey.INVENTORY.name(), FastInventory.class);
+        String paginationId = context.getData(CommonContextKey.PAGINATION_ID.name(), String.class);
+
+        Pagination<?> pagination = inventory.getPagination(paginationId)
+                .orElseThrow(() -> new IllegalStateException(String.format("No pagination with id %s found", paginationId)));
+
+        return pagination.getModel();
+    }
+
+    @Override
+    public boolean accept(Context context) {
+        return context.hasData(CommonContextKey.PAGINATION_ID.name());
+    }
+}

--- a/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/pagination/PreviousPagePlaceholder.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/pagination/PreviousPagePlaceholder.java
@@ -1,0 +1,18 @@
+package com.github.syr0ws.fastinventory.common.placeholder.pagination;
+
+import com.github.syr0ws.fastinventory.api.pagination.PaginationModel;
+import com.github.syr0ws.fastinventory.api.util.Context;
+
+public class PreviousPagePlaceholder extends PaginationPlaceholder {
+
+    @Override
+    public String getName() {
+        return "%previous_page%";
+    }
+
+    @Override
+    public String getValue(Context context) {
+        PaginationModel<?> model = super.getPaginationModel(context);
+        return Integer.toString(model.getPreviousPage());
+    }
+}

--- a/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/pagination/TotalPagesPlaceholder.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/pagination/TotalPagesPlaceholder.java
@@ -1,13 +1,9 @@
 package com.github.syr0ws.fastinventory.common.placeholder.pagination;
 
-import com.github.syr0ws.fastinventory.api.FastInventory;
-import com.github.syr0ws.fastinventory.api.pagination.Pagination;
 import com.github.syr0ws.fastinventory.api.pagination.PaginationModel;
-import com.github.syr0ws.fastinventory.api.placeholder.Placeholder;
 import com.github.syr0ws.fastinventory.api.util.Context;
-import com.github.syr0ws.fastinventory.common.CommonContextKey;
 
-public class TotalPagesPlaceholder implements Placeholder {
+public class TotalPagesPlaceholder extends PaginationPlaceholder {
 
     @Override
     public String getName() {
@@ -16,20 +12,7 @@ public class TotalPagesPlaceholder implements Placeholder {
 
     @Override
     public String getValue(Context context) {
-
-        FastInventory inventory = context.getData(CommonContextKey.INVENTORY.name(), FastInventory.class);
-        String paginationId = context.getData(CommonContextKey.PAGINATION_ID.name(), String.class);
-
-        Pagination<?> pagination = inventory.getPagination(paginationId)
-                .orElseThrow(() -> new IllegalStateException(String.format("No pagination with id %s found", paginationId)));
-
-        PaginationModel<?> model = pagination.getModel();
-
+        PaginationModel<?> model = super.getPaginationModel(context);
         return Integer.toString(model.countPages());
-    }
-
-    @Override
-    public boolean accept(Context context) {
-        return context.hasData(CommonContextKey.PAGINATION_ID.name());
     }
 }

--- a/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/pagination/TotalPagesPlaceholder.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/pagination/TotalPagesPlaceholder.java
@@ -1,0 +1,35 @@
+package com.github.syr0ws.fastinventory.common.placeholder.pagination;
+
+import com.github.syr0ws.fastinventory.api.FastInventory;
+import com.github.syr0ws.fastinventory.api.pagination.Pagination;
+import com.github.syr0ws.fastinventory.api.pagination.PaginationModel;
+import com.github.syr0ws.fastinventory.api.placeholder.Placeholder;
+import com.github.syr0ws.fastinventory.api.util.Context;
+import com.github.syr0ws.fastinventory.common.CommonContextKey;
+
+public class TotalPagesPlaceholder implements Placeholder {
+
+    @Override
+    public String getName() {
+        return "%total_pages%";
+    }
+
+    @Override
+    public String getValue(Context context) {
+
+        FastInventory inventory = context.getData(CommonContextKey.INVENTORY.name(), FastInventory.class);
+        String paginationId = context.getData(CommonContextKey.PAGINATION_ID.name(), String.class);
+
+        Pagination<?> pagination = inventory.getPagination(paginationId)
+                .orElseThrow(() -> new IllegalStateException(String.format("No pagination with id %s found", paginationId)));
+
+        PaginationModel<?> model = pagination.getModel();
+
+        return Integer.toString(model.countPages());
+    }
+
+    @Override
+    public boolean accept(Context context) {
+        return context.hasData(CommonContextKey.PAGINATION_ID.name());
+    }
+}

--- a/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/player/PlayerNamePlaceholder.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/player/PlayerNamePlaceholder.java
@@ -1,4 +1,4 @@
-package com.github.syr0ws.fastinventory.common.placeholder;
+package com.github.syr0ws.fastinventory.common.placeholder.player;
 
 import com.github.syr0ws.fastinventory.api.placeholder.Placeholder;
 import com.github.syr0ws.fastinventory.api.util.Context;

--- a/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/player/PlayerUUIDPlaceholder.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/placeholder/player/PlayerUUIDPlaceholder.java
@@ -1,4 +1,4 @@
-package com.github.syr0ws.fastinventory.common.placeholder;
+package com.github.syr0ws.fastinventory.common.placeholder.player;
 
 import com.github.syr0ws.fastinventory.api.placeholder.Placeholder;
 import com.github.syr0ws.fastinventory.api.util.Context;

--- a/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonInventoryItemProvider.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonInventoryItemProvider.java
@@ -43,7 +43,7 @@ public class CommonInventoryItemProvider implements Provider<InventoryItem> {
 
     @Override
     public String getName() {
-        return CommonProviderEnum.CONTENT_ITEM.name();
+        return CommonProviderType.CONTENT_ITEM.name();
     }
 
     @Override

--- a/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonInventoryProvider.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonInventoryProvider.java
@@ -11,7 +11,12 @@ import com.github.syr0ws.fastinventory.api.placeholder.PlaceholderManager;
 import com.github.syr0ws.fastinventory.api.provider.InventoryProvider;
 import com.github.syr0ws.fastinventory.api.provider.Provider;
 import com.github.syr0ws.fastinventory.api.util.Context;
-import com.github.syr0ws.fastinventory.common.placeholder.*;
+import com.github.syr0ws.fastinventory.common.placeholder.CommonPlaceholder;
+import com.github.syr0ws.fastinventory.common.placeholder.inventory.InventorySizePlaceholder;
+import com.github.syr0ws.fastinventory.common.placeholder.inventory.InventoryTypePlaceholder;
+import com.github.syr0ws.fastinventory.common.placeholder.item.ItemSlotPlaceholder;
+import com.github.syr0ws.fastinventory.common.placeholder.player.PlayerNamePlaceholder;
+import com.github.syr0ws.fastinventory.common.placeholder.player.PlayerUUIDPlaceholder;
 import com.github.syr0ws.fastinventory.internal.SimpleFastInventory;
 import com.github.syr0ws.fastinventory.internal.placeholder.SimplePlaceholderManager;
 import org.bukkit.entity.Player;
@@ -62,11 +67,9 @@ public abstract class CommonInventoryProvider implements InventoryProvider {
     }
 
     protected void addPlaceholders(PlaceholderManager manager) {
-        manager.addPlaceholder(new PlayerNamePlaceholder());
-        manager.addPlaceholder(new PlayerUUIDPlaceholder());
-        manager.addPlaceholder(new InventoryTypePlaceholder());
-        manager.addPlaceholder(new InventorySizePlaceholder());
-        manager.addPlaceholder(new ItemSlotPlaceholder());
+        Arrays.stream(CommonPlaceholder.values())
+                .map(CommonPlaceholder::getPlaceholder)
+                .forEach(manager::addPlaceholder);
     }
 
     protected void addProvider(Provider<?> provider) {

--- a/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonInventoryProvider.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonInventoryProvider.java
@@ -64,6 +64,8 @@ public abstract class CommonInventoryProvider implements InventoryProvider {
         this.addProvider(new CommonInventoryTypeProvider());
         this.addProvider(new CommonInventoryItemProvider(itemParser));
         this.addProvider(new CommonPaginationItemProvider(itemParser));
+        this.addProvider(new CommonPreviousPageItemProvider(itemParser));
+        this.addProvider(new CommonNextPageItemProvider(itemParser));
     }
 
     protected void addPlaceholders(PlaceholderManager manager) {

--- a/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonInventoryTypeProvider.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonInventoryTypeProvider.java
@@ -14,7 +14,7 @@ public class CommonInventoryTypeProvider implements Provider<FastInventoryType> 
 
     @Override
     public String getName() {
-        return CommonProviderEnum.INVENTORY_TYPE.name();
+        return CommonProviderType.INVENTORY_TYPE.name();
     }
 
     @Override

--- a/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonNextPageItemProvider.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonNextPageItemProvider.java
@@ -1,0 +1,22 @@
+package com.github.syr0ws.fastinventory.common.provider;
+
+import com.github.syr0ws.fastinventory.api.config.InventoryItemConfig;
+import com.github.syr0ws.fastinventory.api.config.PaginationConfig;
+import com.github.syr0ws.fastinventory.api.item.ItemParser;
+
+public class CommonNextPageItemProvider extends CommonPageItemProvider {
+
+    public CommonNextPageItemProvider(ItemParser parser) {
+        super(parser);
+    }
+
+    @Override
+    protected InventoryItemConfig getPageItemConfig(PaginationConfig config) {
+        return config.getNextPageItem();
+    }
+
+    @Override
+    public String getName() {
+        return CommonProviderType.PAGINATION_NEXT_PAGE_ITEM.name();
+    }
+}

--- a/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonPageItemProvider.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonPageItemProvider.java
@@ -1,0 +1,51 @@
+package com.github.syr0ws.fastinventory.common.provider;
+
+import com.github.syr0ws.fastinventory.api.config.InventoryConfig;
+import com.github.syr0ws.fastinventory.api.config.InventoryItemConfig;
+import com.github.syr0ws.fastinventory.api.config.PaginationConfig;
+import com.github.syr0ws.fastinventory.api.item.InventoryItem;
+import com.github.syr0ws.fastinventory.api.item.ItemParser;
+import com.github.syr0ws.fastinventory.api.provider.InventoryProvider;
+import com.github.syr0ws.fastinventory.api.provider.Provider;
+import com.github.syr0ws.fastinventory.api.util.Context;
+import com.github.syr0ws.fastinventory.common.CommonContextKey;
+import com.github.syr0ws.fastinventory.internal.item.SimpleInventoryItem;
+import org.bukkit.inventory.ItemStack;
+
+public abstract class CommonPageItemProvider implements Provider<InventoryItem> {
+
+    private final ItemParser parser;
+
+    public CommonPageItemProvider(ItemParser parser) {
+
+        if(parser == null) {
+            throw new IllegalArgumentException("parser cannot be null");
+        }
+
+        this.parser = parser;
+    }
+
+    protected abstract InventoryItemConfig getPageItemConfig(PaginationConfig config);
+
+    @Override
+    public InventoryItem provide(InventoryProvider provider, Context context) {
+
+        InventoryConfig config = provider.getConfig();
+
+        String paginationId = context.getData(CommonContextKey.PAGINATION_ID.name(), String.class);
+
+        PaginationConfig paginationConfig = config.getPaginationConfig(paginationId)
+                .orElseThrow(() -> new NullPointerException(String.format("No pagination found with id %s", paginationId)));
+
+        InventoryItemConfig itemConfig = this.getPageItemConfig(paginationConfig);
+
+        ItemStack item = this.parser.parse(provider, itemConfig.getItemStack(), context);
+
+        return new SimpleInventoryItem(itemConfig.getId(), item, itemConfig.getActions());
+    }
+
+    @Override
+    public Class<InventoryItem> getType() {
+        return InventoryItem.class;
+    }
+}

--- a/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonPaginationItemProvider.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonPaginationItemProvider.java
@@ -47,7 +47,7 @@ public class CommonPaginationItemProvider implements Provider<InventoryItem> {
 
     @Override
     public String getName() {
-        return CommonProviderEnum.PAGINATION_ITEM.name();
+        return CommonProviderType.PAGINATION_ITEM.name();
     }
 
     @Override

--- a/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonPreviousPageItemProvider.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonPreviousPageItemProvider.java
@@ -1,0 +1,22 @@
+package com.github.syr0ws.fastinventory.common.provider;
+
+import com.github.syr0ws.fastinventory.api.config.InventoryItemConfig;
+import com.github.syr0ws.fastinventory.api.config.PaginationConfig;
+import com.github.syr0ws.fastinventory.api.item.ItemParser;
+
+public class CommonPreviousPageItemProvider extends CommonPageItemProvider {
+
+    public CommonPreviousPageItemProvider(ItemParser parser) {
+        super(parser);
+    }
+
+    @Override
+    protected InventoryItemConfig getPageItemConfig(PaginationConfig config) {
+        return config.getPreviousPageItem();
+    }
+
+    @Override
+    public String getName() {
+        return CommonProviderType.PAGINATION_PREVIOUS_PAGE_ITEM.name();
+    }
+}

--- a/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonProviderType.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonProviderType.java
@@ -2,5 +2,11 @@ package com.github.syr0ws.fastinventory.common.provider;
 
 public enum CommonProviderType {
 
-    TITLE, INVENTORY_TYPE, CONTENT_ITEM, PAGINATION, PAGINATION_ITEM;
+    TITLE,
+    INVENTORY_TYPE,
+    CONTENT_ITEM,
+    PAGINATION,
+    PAGINATION_ITEM,
+    PAGINATION_PREVIOUS_PAGE_ITEM,
+    PAGINATION_NEXT_PAGE_ITEM
 }

--- a/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonProviderType.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonProviderType.java
@@ -1,6 +1,6 @@
 package com.github.syr0ws.fastinventory.common.provider;
 
-public enum CommonProviderEnum {
+public enum CommonProviderType {
 
     TITLE, INVENTORY_TYPE, CONTENT_ITEM, PAGINATION, PAGINATION_ITEM;
 }

--- a/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonTitleProvider.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/provider/CommonTitleProvider.java
@@ -27,7 +27,7 @@ public class CommonTitleProvider implements Provider<String> {
 
     @Override
     public String getName() {
-        return CommonProviderEnum.TITLE.name();
+        return CommonProviderType.TITLE.name();
     }
 
     @Override

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/SimpleFastInventory.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/SimpleFastInventory.java
@@ -12,7 +12,7 @@ import com.github.syr0ws.fastinventory.api.pagination.Pagination;
 import com.github.syr0ws.fastinventory.api.provider.InventoryProvider;
 import com.github.syr0ws.fastinventory.api.util.Context;
 import com.github.syr0ws.fastinventory.common.CommonContextKey;
-import com.github.syr0ws.fastinventory.common.provider.CommonProviderEnum;
+import com.github.syr0ws.fastinventory.common.provider.CommonProviderType;
 import com.github.syr0ws.fastinventory.internal.util.SimpleContext;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -86,7 +86,7 @@ public class SimpleFastInventory implements FastInventory {
                 Context context = this.getDefaultContext();
                 context.addData(CommonContextKey.SLOT.name(), slot, Integer.class);
 
-                InventoryItem item = this.provider.provide(CommonProviderEnum.CONTENT_ITEM.name(), InventoryItem.class, context)
+                InventoryItem item = this.provider.provide(CommonProviderType.CONTENT_ITEM.name(), InventoryItem.class, context)
                         .orElse(null);
 
                 if(item == null) {
@@ -106,13 +106,13 @@ public class SimpleFastInventory implements FastInventory {
 
     @Override
     public String getTitle() {
-        return this.provider.provide(CommonProviderEnum.TITLE.name(), String.class, this.getDefaultContext())
+        return this.provider.provide(CommonProviderType.TITLE.name(), String.class, this.getDefaultContext())
                 .orElse("");
     }
 
     @Override
     public FastInventoryType getType() {
-        return this.provider.provide(CommonProviderEnum.INVENTORY_TYPE.name(), FastInventoryType.class, this.getDefaultContext())
+        return this.provider.provide(CommonProviderType.INVENTORY_TYPE.name(), FastInventoryType.class, this.getDefaultContext())
                 .orElseThrow(() -> new InventoryException("No provider found for FastInventoryType"));
     }
 

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/SimpleInventoryItemConfig.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/SimpleInventoryItemConfig.java
@@ -4,6 +4,7 @@ import com.github.syr0ws.fastinventory.api.action.ClickAction;
 import com.github.syr0ws.fastinventory.api.config.InventoryItemConfig;
 import org.bukkit.inventory.ItemStack;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -29,7 +30,7 @@ public class SimpleInventoryItemConfig implements InventoryItemConfig {
 
         this.id = id;
         this.item = item;
-        this.actions = Collections.unmodifiableList(actions);
+        this.actions = actions;
     }
 
     @Override

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/SimplePaginationConfig.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/SimplePaginationConfig.java
@@ -3,6 +3,8 @@ package com.github.syr0ws.fastinventory.internal.config;
 import com.github.syr0ws.fastinventory.api.config.InventoryItemConfig;
 import com.github.syr0ws.fastinventory.api.config.PaginationConfig;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -11,8 +13,12 @@ public class SimplePaginationConfig implements PaginationConfig {
     private final String id;
     private final List<Integer> slots;
     private final InventoryItemConfig item;
+    private final InventoryItemConfig previousPageItem;
+    private final InventoryItemConfig nextPageItem;
+    private final Set<Integer> previousPageItemSlots;
+    private final Set<Integer> nextPageItemSlots;
 
-    public SimplePaginationConfig(String id, Set<Integer> slots, InventoryItemConfig item) {
+    public SimplePaginationConfig(String id, Set<Integer> slots, InventoryItemConfig item, InventoryItemConfig prevousPageItem, InventoryItemConfig nextPageItem, List<Integer> previousPageItemSlots, List<Integer> nextPageItemSlots) {
 
         if (id == null || id.isEmpty()) {
             throw new IllegalArgumentException("id cannot be null or empty");
@@ -29,6 +35,10 @@ public class SimplePaginationConfig implements PaginationConfig {
         this.id = id;
         this.slots = slots.stream().sorted().toList();
         this.item = item;
+        this.previousPageItem = prevousPageItem;
+        this.nextPageItem = nextPageItem;
+        this.previousPageItemSlots = Set.copyOf(previousPageItemSlots);
+        this.nextPageItemSlots = Set.copyOf(nextPageItemSlots);
     }
 
     @Override
@@ -44,5 +54,25 @@ public class SimplePaginationConfig implements PaginationConfig {
     @Override
     public InventoryItemConfig getItem() {
         return this.item;
+    }
+
+    @Override
+    public InventoryItemConfig getPreviousPageItem() {
+        return this.previousPageItem;
+    }
+
+    @Override
+    public InventoryItemConfig getNextPageItem() {
+        return this.nextPageItem;
+    }
+
+    @Override
+    public Set<Integer> getPreviousPageItemSlots() {
+        return this.previousPageItemSlots;
+    }
+
+    @Override
+    public Set<Integer> getNextPageItemSlots() {
+        return this.nextPageItemSlots;
     }
 }

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/YamlInventoryPaginationLoader.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/YamlInventoryPaginationLoader.java
@@ -3,8 +3,11 @@ package com.github.syr0ws.fastinventory.internal.config.yaml;
 import com.github.syr0ws.fastinventory.api.config.InventoryItemConfig;
 import com.github.syr0ws.fastinventory.api.config.PaginationConfig;
 import com.github.syr0ws.fastinventory.api.config.exception.InventoryConfigException;
+import com.github.syr0ws.fastinventory.common.action.NextPageAction;
+import com.github.syr0ws.fastinventory.common.action.PreviousPageAction;
 import com.github.syr0ws.fastinventory.internal.config.SimplePaginationConfig;
 import com.github.syr0ws.fastinventory.internal.config.yaml.item.YamlInventoryItemLoader;
+import com.github.syr0ws.fastinventory.internal.util.Pair;
 import org.bukkit.configuration.ConfigurationSection;
 
 import java.util.*;
@@ -15,6 +18,9 @@ public class YamlInventoryPaginationLoader {
     private static final String PAGINATION_ID_KEY = "id";
     private static final String PAGINATION_SYMBOL_KEY = "symbol";
     private static final String PAGINATION_ITEM_KEY = "pagination-item";
+    private static final String PAGE_ITEM_SYMBOL_KEY = "symbol";
+    private static final String PREVIOUS_PAGE_ITEM_KEY = "previous-page-item";
+    private static final String NEXT_PAGE_ITEM_KEY = "next-page-item";
 
     private final YamlInventoryItemLoader itemLoader;
 
@@ -57,36 +63,94 @@ public class YamlInventoryPaginationLoader {
 
     private PaginationConfig loadPagination(ConfigurationSection section, Map<Character, List<Integer>> symbolSlots) throws InventoryConfigException {
 
-        // Loading the pagination id.
+        String paginationId = this.loadPaginationId(section);
+        char paginationSymbol = this.loadPaginationSymbol(section);
+        List<Integer> slots = this.loadPaginationSlots(section, paginationSymbol, symbolSlots);
+        InventoryItemConfig item = this.loadPaginationItem(section);
+
+        Pair<InventoryItemConfig, List<Integer>> previousPageItem = this.loadPageItem(section, PREVIOUS_PAGE_ITEM_KEY, symbolSlots);
+        Pair<InventoryItemConfig, List<Integer>> nextPageItem = this.loadPageItem(section, NEXT_PAGE_ITEM_KEY, symbolSlots);
+
+        previousPageItem.key().getActions().add(new PreviousPageAction(paginationId));
+        nextPageItem.key().getActions().add(new NextPageAction(paginationId));
+
+        return new SimplePaginationConfig(
+                paginationId,
+                new HashSet<>(slots),
+                item,
+                previousPageItem.key(),
+                nextPageItem.key(),
+                previousPageItem.value(),
+                nextPageItem.value()
+        );
+    }
+
+    private String loadPaginationId(ConfigurationSection section) throws InventoryConfigException {
+
         String paginationId = section.getString(PAGINATION_ID_KEY);
 
         if(paginationId == null || paginationId.isEmpty()) {
             throw new InventoryConfigException(String.format("Property '%s' missing or empty in pagination at '%s'", PAGINATION_ID_KEY, section.getCurrentPath()));
         }
 
-        // Loading the symbol used in the pattern.
+        return paginationId;
+    }
+
+    private char loadPaginationSymbol(ConfigurationSection section) throws InventoryConfigException {
+
         String symbol = section.getString(PAGINATION_SYMBOL_KEY);
 
         if (symbol == null || symbol.length() != 1) {
             throw new InventoryConfigException(String.format("Property '%s' missing or invalid in pagination at '%s'", PAGINATION_SYMBOL_KEY, section.getCurrentPath()));
         }
 
-        // Loading the pagination item.
+        return symbol.charAt(0);
+    }
+
+    private InventoryItemConfig loadPaginationItem(ConfigurationSection section) throws InventoryConfigException {
+
         ConfigurationSection paginationItemSection = section.getConfigurationSection(PAGINATION_ITEM_KEY);
 
         if(paginationItemSection == null) {
             throw new InventoryConfigException(String.format("Property '%s' missing or invalid in pagination at '%s'", PAGINATION_ITEM_KEY, section.getCurrentPath()));
         }
 
-        InventoryItemConfig item = this.itemLoader.loadItem(paginationItemSection);
+        return this.itemLoader.loadItem(paginationItemSection);
+    }
 
-        // Retrieving pagination slots.
+    private List<Integer> loadPaginationSlots(ConfigurationSection section, char paginationSymbol, Map<Character, List<Integer>> symbolSlots) throws InventoryConfigException {
+
+        List<Integer> slots = symbolSlots.getOrDefault(paginationSymbol, Collections.emptyList());
+
+        if(slots.isEmpty()) {
+            throw new InventoryConfigException(String.format("Symbol '%s' not found in pattern for pagination at '%s'", paginationSymbol, section.getCurrentPath()));
+        }
+
+        return slots;
+    }
+
+    private Pair<InventoryItemConfig, List<Integer>> loadPageItem(ConfigurationSection section, String key, Map<Character, List<Integer>> symbolSlots) throws InventoryConfigException {
+
+        ConfigurationSection pageItemSection = section.getConfigurationSection(key);
+
+        if(pageItemSection == null) {
+            throw new InventoryConfigException(String.format("Property '%s' missing or not a section at '%s'", key, section.getCurrentPath()));
+        }
+
+        InventoryItemConfig item = this.itemLoader.loadItem(pageItemSection);
+
+        String symbol = pageItemSection.getString(PAGE_ITEM_SYMBOL_KEY);
+
+        if (symbol == null || symbol.length() != 1) {
+            throw new InventoryConfigException(String.format("Property '%s' missing or invalid at '%s'", PAGE_ITEM_SYMBOL_KEY, section.getCurrentPath()));
+        }
+
         List<Integer> slots = symbolSlots.getOrDefault(symbol.charAt(0), Collections.emptyList());
 
         if(slots.isEmpty()) {
             throw new InventoryConfigException(String.format("Symbol '%s' not found in pattern for pagination at '%s'", symbol, section.getCurrentPath()));
         }
 
-        return new SimplePaginationConfig(paginationId, new HashSet<>(slots), item);
+        return new Pair<>(item, slots);
     }
 }

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/item/YamlInventoryItemLoader.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/item/YamlInventoryItemLoader.java
@@ -65,7 +65,7 @@ public class YamlInventoryItemLoader {
         ConfigurationSection actionsSection = section.getConfigurationSection(ACTIONS_KEY);
 
         if(actionsSection == null) {
-            return Collections.emptyList();
+            return new ArrayList<>();
         }
 
         List<ClickAction> actions = new ArrayList<>();

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/pagination/SimplePagination.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/pagination/SimplePagination.java
@@ -2,6 +2,7 @@ package com.github.syr0ws.fastinventory.internal.pagination;
 
 import com.github.syr0ws.fastinventory.api.FastInventory;
 import com.github.syr0ws.fastinventory.api.InventoryContent;
+import com.github.syr0ws.fastinventory.api.config.PaginationConfig;
 import com.github.syr0ws.fastinventory.api.item.InventoryItem;
 import com.github.syr0ws.fastinventory.api.pagination.Pagination;
 import com.github.syr0ws.fastinventory.api.pagination.PaginationModel;
@@ -46,6 +47,11 @@ public class SimplePagination<T> implements Pagination<T> {
 
     @Override
     public void update() {
+        this.updatePaginationItems();
+        this.updatePageItems();
+    }
+
+    private void updatePaginationItems() {
 
         InventoryProvider provider = this.inventory.getProvider();
         InventoryContent content = this.inventory.getContent();
@@ -75,6 +81,28 @@ public class SimplePagination<T> implements Pagination<T> {
 
             i++;
         }
+    }
+
+    private void updatePageItems() {
+
+        InventoryProvider provider = this.inventory.getProvider();
+        InventoryContent content = this.inventory.getContent();
+
+        Context context = this.getPaginationContext();
+
+        PaginationConfig paginationConfig = provider.getConfig()
+                .getPaginationConfig(this.id)
+                .orElse(null);
+
+        if(paginationConfig == null) {
+            return; // Should not happen.
+        }
+
+        provider.provide(CommonProviderType.PAGINATION_PREVIOUS_PAGE_ITEM.name(), InventoryItem.class, context)
+                .ifPresent(item -> content.setItem(item, paginationConfig.getPreviousPageItemSlots()));
+
+        provider.provide(CommonProviderType.PAGINATION_NEXT_PAGE_ITEM.name(), InventoryItem.class, context)
+                .ifPresent(item -> content.setItem(item, paginationConfig.getNextPageItemSlots()));
     }
 
     @Override

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/pagination/SimplePagination.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/pagination/SimplePagination.java
@@ -8,7 +8,7 @@ import com.github.syr0ws.fastinventory.api.pagination.PaginationModel;
 import com.github.syr0ws.fastinventory.api.provider.InventoryProvider;
 import com.github.syr0ws.fastinventory.api.util.Context;
 import com.github.syr0ws.fastinventory.common.CommonContextKey;
-import com.github.syr0ws.fastinventory.common.provider.CommonProviderEnum;
+import com.github.syr0ws.fastinventory.common.provider.CommonProviderType;
 
 import java.util.Collections;
 import java.util.List;
@@ -64,7 +64,7 @@ public class SimplePagination<T> implements Pagination<T> {
                 context.addData(CommonContextKey.SLOT.name(), slot, Integer.class);
                 context.addData(CommonContextKey.PAGINATION_ITEM.name(), items.get(i), this.model.getDataType());
 
-                item = provider.provide(CommonProviderEnum.PAGINATION_ITEM.name(), InventoryItem.class, context).orElse(null);
+                item = provider.provide(CommonProviderType.PAGINATION_ITEM.name(), InventoryItem.class, context).orElse(null);
             }
 
             if(item == null) {

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/pagination/SimplePagination.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/pagination/SimplePagination.java
@@ -92,17 +92,24 @@ public class SimplePagination<T> implements Pagination<T> {
 
         PaginationConfig paginationConfig = provider.getConfig()
                 .getPaginationConfig(this.id)
-                .orElse(null);
+                .orElseThrow(() -> new NullPointerException("Pagination not found"));
 
-        if(paginationConfig == null) {
-            return; // Should not happen.
+        if(this.model.hasPreviousPage()) {
+
+            provider.provide(CommonProviderType.PAGINATION_PREVIOUS_PAGE_ITEM.name(), InventoryItem.class, context)
+                    .ifPresent(item -> content.setItem(item, paginationConfig.getPreviousPageItemSlots()));
+
+        } else {
+            content.removeItems(paginationConfig.getPreviousPageItemSlots());
         }
 
-        provider.provide(CommonProviderType.PAGINATION_PREVIOUS_PAGE_ITEM.name(), InventoryItem.class, context)
-                .ifPresent(item -> content.setItem(item, paginationConfig.getPreviousPageItemSlots()));
+        if(this.model.hasNextPage()) {
 
-        provider.provide(CommonProviderType.PAGINATION_NEXT_PAGE_ITEM.name(), InventoryItem.class, context)
-                .ifPresent(item -> content.setItem(item, paginationConfig.getNextPageItemSlots()));
+            provider.provide(CommonProviderType.PAGINATION_NEXT_PAGE_ITEM.name(), InventoryItem.class, context)
+                    .ifPresent(item -> content.setItem(item, paginationConfig.getNextPageItemSlots()));
+        } else {
+            content.removeItems(paginationConfig.getNextPageItemSlots());
+        }
     }
 
     @Override

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/pagination/SimplePaginationModel.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/pagination/SimplePaginationModel.java
@@ -100,6 +100,16 @@ public class SimplePaginationModel<T> implements PaginationModel<T> {
     }
 
     @Override
+    public int getPreviousPage() {
+        return this.hasPreviousPage() ? this.currentPage - 1 : this.getFirstPage();
+    }
+
+    @Override
+    public int getNextPage() {
+        return this.hasNextPage() ? this.currentPage + 1 : this.getLastPage();
+    }
+
+    @Override
     public boolean hasPreviousPage() {
         return this.currentPage > 1;
     }

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/util/Pair.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/util/Pair.java
@@ -1,0 +1,5 @@
+package com.github.syr0ws.fastinventory.internal.util;
+
+public record Pair<K,V>(K key, V value) {
+
+}


### PR DESCRIPTION
- Previous and next page items are now parts of the pagination itself
- Adding new placeholders related to pagination and reworking the existing ones
- Switch page items are no longer displayed if there is no previous or next page