### PR TITLE
feat: adding click type condition when executing an action

### DIFF
--- a/src/main/java/com/github/syr0ws/fastinventory/api/action/ClickAction.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/api/action/ClickAction.java
@@ -2,9 +2,13 @@ package com.github.syr0ws.fastinventory.api.action;
 
 import com.github.syr0ws.fastinventory.api.event.FastInventoryClickEvent;
 
+import java.util.Set;
+
 public interface ClickAction {
 
     void execute(FastInventoryClickEvent event);
+
+    Set<ClickType> getClickTypes();
 
     String getName();
 }

--- a/src/main/java/com/github/syr0ws/fastinventory/api/action/ClickType.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/api/action/ClickType.java
@@ -1,0 +1,12 @@
+package com.github.syr0ws.fastinventory.api.action;
+
+import java.util.Arrays;
+
+public enum ClickType {
+
+    LEFT, RIGHT, MIDDLE, ALL;
+
+    public static boolean isClickType(String name) {
+        return Arrays.stream(values()).anyMatch(value -> value.name().equalsIgnoreCase(name));
+    }
+}

--- a/src/main/java/com/github/syr0ws/fastinventory/common/action/CloseAction.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/action/CloseAction.java
@@ -1,12 +1,18 @@
 package com.github.syr0ws.fastinventory.common.action;
 
-import com.github.syr0ws.fastinventory.api.action.ClickAction;
+import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.event.FastInventoryClickEvent;
 import org.bukkit.entity.Player;
 
-public class CloseAction implements ClickAction {
+import java.util.Set;
+
+public class CloseAction extends CommonAction {
 
     public static final String ACTION_NAME = "CLOSE";
+
+    public CloseAction(Set<ClickType> clickTypes) {
+        super(clickTypes);
+    }
 
     @Override
     public void execute(FastInventoryClickEvent event) {

--- a/src/main/java/com/github/syr0ws/fastinventory/common/action/CommonAction.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/action/CommonAction.java
@@ -1,0 +1,26 @@
+package com.github.syr0ws.fastinventory.common.action;
+
+import com.github.syr0ws.fastinventory.api.action.ClickAction;
+import com.github.syr0ws.fastinventory.api.action.ClickType;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class CommonAction implements ClickAction {
+
+    private final Set<ClickType> clickTypes = new HashSet<>();
+
+    public CommonAction(Set<ClickType> clickTypes) {
+
+        if(clickTypes == null) {
+            throw new IllegalArgumentException("clickTypes cannot be null");
+        }
+
+        this.clickTypes.addAll(clickTypes);
+    }
+
+    @Override
+    public Set<ClickType> getClickTypes() {
+        return this.clickTypes;
+    }
+}

--- a/src/main/java/com/github/syr0ws/fastinventory/common/action/MessageAction.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/action/MessageAction.java
@@ -1,19 +1,22 @@
 package com.github.syr0ws.fastinventory.common.action;
 
 import com.github.syr0ws.fastinventory.api.FastInventory;
-import com.github.syr0ws.fastinventory.api.action.ClickAction;
+import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.event.FastInventoryClickEvent;
 import com.github.syr0ws.fastinventory.api.placeholder.PlaceholderManager;
 import com.github.syr0ws.fastinventory.api.provider.InventoryProvider;
 import org.bukkit.entity.Player;
 
-public class MessageAction implements ClickAction {
+import java.util.Set;
+
+public class MessageAction extends CommonAction {
 
     public static final String ACTION_NAME = "MESSAGE";
 
     private final String message;
 
-    public MessageAction(String message) {
+    public MessageAction(Set<ClickType> clickTypes, String message) {
+        super(clickTypes);
 
         if (message == null) {
             throw new IllegalArgumentException("message cannot be null");

--- a/src/main/java/com/github/syr0ws/fastinventory/common/action/NextPageAction.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/action/NextPageAction.java
@@ -1,17 +1,20 @@
 package com.github.syr0ws.fastinventory.common.action;
 
 import com.github.syr0ws.fastinventory.api.FastInventory;
-import com.github.syr0ws.fastinventory.api.action.ClickAction;
+import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.event.FastInventoryClickEvent;
 import com.github.syr0ws.fastinventory.api.pagination.Pagination;
 
-public class NextPageAction implements ClickAction {
+import java.util.Set;
+
+public class NextPageAction extends CommonAction {
 
     public static final String ACTION_NAME = "NEXT_PAGE";
 
     private final String paginationId;
 
-    public NextPageAction(String paginationId) {
+    public NextPageAction(Set<ClickType> clickTypes, String paginationId) {
+        super(clickTypes);
 
         if (paginationId == null || paginationId.isEmpty()) {
             throw new IllegalArgumentException("paginationId cannot be null or empty");

--- a/src/main/java/com/github/syr0ws/fastinventory/common/action/PlayerCommandAction.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/action/PlayerCommandAction.java
@@ -1,19 +1,22 @@
 package com.github.syr0ws.fastinventory.common.action;
 
 import com.github.syr0ws.fastinventory.api.FastInventory;
-import com.github.syr0ws.fastinventory.api.action.ClickAction;
+import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.event.FastInventoryClickEvent;
 import com.github.syr0ws.fastinventory.api.placeholder.PlaceholderManager;
 import com.github.syr0ws.fastinventory.api.provider.InventoryProvider;
 import org.bukkit.entity.Player;
 
-public class PlayerCommandAction implements ClickAction {
+import java.util.Set;
+
+public class PlayerCommandAction extends CommonAction {
 
     public static final String ACTION_NAME = "PLAYER_COMMAND";
 
     private final String command;
 
-    public PlayerCommandAction(String command) {
+    public PlayerCommandAction(Set<ClickType> clickTypes, String command) {
+        super(clickTypes);
 
         if (command == null || command.isEmpty()) {
             throw new IllegalArgumentException("command cannot null or empty");

--- a/src/main/java/com/github/syr0ws/fastinventory/common/action/PreviousPageAction.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/action/PreviousPageAction.java
@@ -1,17 +1,20 @@
 package com.github.syr0ws.fastinventory.common.action;
 
 import com.github.syr0ws.fastinventory.api.FastInventory;
-import com.github.syr0ws.fastinventory.api.action.ClickAction;
+import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.event.FastInventoryClickEvent;
 import com.github.syr0ws.fastinventory.api.pagination.Pagination;
 
-public class PreviousPageAction implements ClickAction {
+import java.util.Set;
+
+public class PreviousPageAction extends CommonAction {
 
     public static final String ACTION_NAME = "PREVIOUS_PAGE";
 
     private final String paginationId;
 
-    public PreviousPageAction(String paginationId) {
+    public PreviousPageAction(Set<ClickType> clickTypes, String paginationId) {
+        super(clickTypes);
 
         if (paginationId == null || paginationId.isEmpty()) {
             throw new IllegalArgumentException("paginationId cannot be null or empty");

--- a/src/main/java/com/github/syr0ws/fastinventory/common/action/ServerCommandAction.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/action/ServerCommandAction.java
@@ -1,19 +1,22 @@
 package com.github.syr0ws.fastinventory.common.action;
 
 import com.github.syr0ws.fastinventory.api.FastInventory;
-import com.github.syr0ws.fastinventory.api.action.ClickAction;
+import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.event.FastInventoryClickEvent;
 import com.github.syr0ws.fastinventory.api.placeholder.PlaceholderManager;
 import com.github.syr0ws.fastinventory.api.provider.InventoryProvider;
 import org.bukkit.Bukkit;
 
-public class ServerCommandAction implements ClickAction {
+import java.util.Set;
+
+public class ServerCommandAction extends CommonAction {
 
     public static final String ACTION_NAME = "SERVER_COMMAND";
 
     private final String command;
 
-    public ServerCommandAction(String command) {
+    public ServerCommandAction(Set<ClickType> clickTypes, String command) {
+        super(clickTypes);
 
         if (command == null || command.isEmpty()) {
             throw new IllegalArgumentException("command cannot null or empty");

--- a/src/main/java/com/github/syr0ws/fastinventory/common/config/yaml/YamlCommonActionLoader.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/config/yaml/YamlCommonActionLoader.java
@@ -1,0 +1,46 @@
+package com.github.syr0ws.fastinventory.common.config.yaml;
+
+import com.github.syr0ws.fastinventory.api.action.ClickType;
+import com.github.syr0ws.fastinventory.api.config.action.ClickActionLoader;
+import com.github.syr0ws.fastinventory.api.config.exception.InventoryConfigException;
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public abstract class YamlCommonActionLoader implements ClickActionLoader<ConfigurationSection> {
+
+    private static final String CLICK_TYPES_KEY = "click-types";
+
+    protected Set<ClickType> loadClickTypes(ConfigurationSection section) throws InventoryConfigException {
+
+        Set<ClickType> clickTypes = new HashSet<>();
+
+        // If the property is not set, all clicks are handled by default.
+        if(!section.isSet(CLICK_TYPES_KEY)) {
+            clickTypes.add(ClickType.ALL);
+            return clickTypes;
+        }
+
+        // When the property is set, checking that it is a list.
+        if(!section.isList(CLICK_TYPES_KEY)) {
+            throw new InventoryConfigException(String.format("Property '%s.%s' must be a list", section.getCurrentPath(), CLICK_TYPES_KEY));
+        }
+
+        List<String> clickTypeNames = section.getStringList(CLICK_TYPES_KEY);
+
+        for(String clickTypeName : clickTypeNames) {
+
+            String parsedName = clickTypeName.toUpperCase();
+
+            if(!ClickType.isClickType(parsedName)) {
+                throw new InventoryConfigException(String.format("Invalid click type '%s' at '%s.%s'", clickTypeName, section.getCurrentPath(), CLICK_TYPES_KEY));
+            }
+
+            clickTypes.add(ClickType.valueOf(parsedName));
+        }
+
+        return clickTypes;
+    }
+}

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/YamlInventoryPaginationLoader.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/YamlInventoryPaginationLoader.java
@@ -1,5 +1,6 @@
 package com.github.syr0ws.fastinventory.internal.config.yaml;
 
+import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.config.InventoryItemConfig;
 import com.github.syr0ws.fastinventory.api.config.PaginationConfig;
 import com.github.syr0ws.fastinventory.api.config.exception.InventoryConfigException;
@@ -77,10 +78,10 @@ public class YamlInventoryPaginationLoader {
         SimpleInventoryItemConfig nextPageItem = nextPage.key();
 
         previousPageItem.setId(IdUtil.getPaginationPreviousPageItemId(paginationId));
-        previousPageItem.getActions().add(new PreviousPageAction(paginationId));
+        previousPageItem.getActions().add(new PreviousPageAction(Collections.singleton(ClickType.ALL), paginationId));
 
         nextPageItem.setId(IdUtil.getPaginationNextPageItemId(paginationId));
-        nextPageItem.getActions().add(new NextPageAction(paginationId));
+        nextPageItem.getActions().add(new NextPageAction(Collections.singleton(ClickType.ALL), paginationId));
 
         return new SimplePaginationConfig(
                 paginationId,

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlCloseActionLoader.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlCloseActionLoader.java
@@ -1,15 +1,20 @@
 package com.github.syr0ws.fastinventory.internal.config.yaml.action;
 
 import com.github.syr0ws.fastinventory.api.action.ClickAction;
-import com.github.syr0ws.fastinventory.api.config.action.ClickActionLoader;
+import com.github.syr0ws.fastinventory.api.action.ClickType;
+import com.github.syr0ws.fastinventory.api.config.exception.InventoryConfigException;
 import com.github.syr0ws.fastinventory.common.action.CloseAction;
+import com.github.syr0ws.fastinventory.common.config.yaml.YamlCommonActionLoader;
 import org.bukkit.configuration.ConfigurationSection;
 
-public class YamlCloseActionLoader implements ClickActionLoader<ConfigurationSection> {
+import java.util.Set;
+
+public class YamlCloseActionLoader extends YamlCommonActionLoader {
 
     @Override
-    public ClickAction load(ConfigurationSection section) {
-        return new CloseAction();
+    public ClickAction load(ConfigurationSection section) throws InventoryConfigException {
+        Set<ClickType> clickTypes = super.loadClickTypes(section);
+        return new CloseAction(clickTypes);
     }
 
     @Override

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlMessageActionLoader.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlMessageActionLoader.java
@@ -1,17 +1,22 @@
 package com.github.syr0ws.fastinventory.internal.config.yaml.action;
 
 import com.github.syr0ws.fastinventory.api.action.ClickAction;
-import com.github.syr0ws.fastinventory.api.config.action.ClickActionLoader;
+import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.config.exception.InventoryConfigException;
 import com.github.syr0ws.fastinventory.common.action.MessageAction;
+import com.github.syr0ws.fastinventory.common.config.yaml.YamlCommonActionLoader;
 import org.bukkit.configuration.ConfigurationSection;
 
-public class YamlMessageActionLoader implements ClickActionLoader<ConfigurationSection> {
+import java.util.Set;
+
+public class YamlMessageActionLoader extends YamlCommonActionLoader {
 
     private static final String MESSAGE_KEY = "message";
 
     @Override
     public ClickAction load(ConfigurationSection section) throws InventoryConfigException {
+
+        Set<ClickType> clickTypes = super.loadClickTypes(section);
 
         if (!section.isString(MESSAGE_KEY)) {
             throw new InventoryConfigException(String.format("Property '%s' missing at '%s'", MESSAGE_KEY, section.getCurrentPath()));
@@ -19,7 +24,7 @@ public class YamlMessageActionLoader implements ClickActionLoader<ConfigurationS
 
         String message = section.getString(MESSAGE_KEY);
 
-        return new MessageAction(message);
+        return new MessageAction(clickTypes, message);
     }
 
     @Override

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlNextPageActionLoader.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlNextPageActionLoader.java
@@ -1,18 +1,22 @@
 package com.github.syr0ws.fastinventory.internal.config.yaml.action;
 
 import com.github.syr0ws.fastinventory.api.action.ClickAction;
+import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.config.exception.InventoryConfigException;
 import com.github.syr0ws.fastinventory.common.action.NextPageAction;
 import org.bukkit.configuration.ConfigurationSection;
+
+import java.util.Set;
 
 public class YamlNextPageActionLoader extends YamlPageActionLoader {
 
     @Override
     public ClickAction load(ConfigurationSection section) throws InventoryConfigException {
 
+        Set<ClickType> clickTypes = super.loadClickTypes(section);
         String paginationId = super.getPaginationId(section);
 
-        return new NextPageAction(paginationId);
+        return new NextPageAction(clickTypes, paginationId);
     }
 
     @Override

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlPageActionLoader.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlPageActionLoader.java
@@ -1,10 +1,10 @@
 package com.github.syr0ws.fastinventory.internal.config.yaml.action;
 
-import com.github.syr0ws.fastinventory.api.config.action.ClickActionLoader;
 import com.github.syr0ws.fastinventory.api.config.exception.InventoryConfigException;
+import com.github.syr0ws.fastinventory.common.config.yaml.YamlCommonActionLoader;
 import org.bukkit.configuration.ConfigurationSection;
 
-public abstract class YamlPageActionLoader implements ClickActionLoader<ConfigurationSection> {
+public abstract class YamlPageActionLoader extends YamlCommonActionLoader {
 
     private static final String PAGINATION_ID_KEY = "pagination-id";
 

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlPlayerCommandActionLoader.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlPlayerCommandActionLoader.java
@@ -1,17 +1,22 @@
 package com.github.syr0ws.fastinventory.internal.config.yaml.action;
 
 import com.github.syr0ws.fastinventory.api.action.ClickAction;
-import com.github.syr0ws.fastinventory.api.config.action.ClickActionLoader;
+import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.config.exception.InventoryConfigException;
 import com.github.syr0ws.fastinventory.common.action.PlayerCommandAction;
+import com.github.syr0ws.fastinventory.common.config.yaml.YamlCommonActionLoader;
 import org.bukkit.configuration.ConfigurationSection;
 
-public class YamlPlayerCommandActionLoader implements ClickActionLoader<ConfigurationSection> {
+import java.util.Set;
+
+public class YamlPlayerCommandActionLoader extends YamlCommonActionLoader {
 
     private static final String COMMAND_KEY = "command";
 
     @Override
     public ClickAction load(ConfigurationSection section) throws InventoryConfigException {
+
+        Set<ClickType> clickTypes = super.loadClickTypes(section);
 
         if (!section.isString(COMMAND_KEY)) {
             throw new InventoryConfigException(String.format("Property '%s' not found or not a string at '%s'", COMMAND_KEY, section.getCurrentPath()));
@@ -23,7 +28,7 @@ public class YamlPlayerCommandActionLoader implements ClickActionLoader<Configur
             command = command.substring(1);
         }
 
-        return new PlayerCommandAction(command);
+        return new PlayerCommandAction(clickTypes, command);
     }
 
     @Override

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlPreviousPageActionLoader.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlPreviousPageActionLoader.java
@@ -1,18 +1,22 @@
 package com.github.syr0ws.fastinventory.internal.config.yaml.action;
 
 import com.github.syr0ws.fastinventory.api.action.ClickAction;
+import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.config.exception.InventoryConfigException;
 import com.github.syr0ws.fastinventory.common.action.PreviousPageAction;
 import org.bukkit.configuration.ConfigurationSection;
+
+import java.util.Set;
 
 public class YamlPreviousPageActionLoader extends YamlPageActionLoader {
 
     @Override
     public ClickAction load(ConfigurationSection section) throws InventoryConfigException {
 
+        Set<ClickType> clickTypes = super.loadClickTypes(section);
         String paginationId = super.getPaginationId(section);
 
-        return new PreviousPageAction(paginationId);
+        return new PreviousPageAction(clickTypes, paginationId);
     }
 
     @Override

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlServerCommandActionLoader.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlServerCommandActionLoader.java
@@ -1,17 +1,22 @@
 package com.github.syr0ws.fastinventory.internal.config.yaml.action;
 
 import com.github.syr0ws.fastinventory.api.action.ClickAction;
-import com.github.syr0ws.fastinventory.api.config.action.ClickActionLoader;
+import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.config.exception.InventoryConfigException;
 import com.github.syr0ws.fastinventory.common.action.ServerCommandAction;
+import com.github.syr0ws.fastinventory.common.config.yaml.YamlCommonActionLoader;
 import org.bukkit.configuration.ConfigurationSection;
 
-public class YamlServerCommandActionLoader implements ClickActionLoader<ConfigurationSection> {
+import java.util.Set;
+
+public class YamlServerCommandActionLoader extends YamlCommonActionLoader {
 
     private static final String COMMAND_KEY = "command";
 
     @Override
     public ClickAction load(ConfigurationSection section) throws InventoryConfigException {
+
+        Set<ClickType> clickTypes = super.loadClickTypes(section);
 
         if (!section.isString(COMMAND_KEY)) {
             throw new InventoryConfigException(String.format("Property '%s' not found or not a string at '%s'", COMMAND_KEY, section.getCurrentPath()));
@@ -23,7 +28,7 @@ public class YamlServerCommandActionLoader implements ClickActionLoader<Configur
             command = command.substring(1);
         }
 
-        return new ServerCommandAction(command);
+        return new ServerCommandAction(clickTypes, command);
     }
 
     @Override

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/listener/FastInventoryListener.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/listener/FastInventoryListener.java
@@ -3,6 +3,8 @@ package com.github.syr0ws.fastinventory.internal.listener;
 import com.github.syr0ws.fastinventory.api.FastInventory;
 import com.github.syr0ws.fastinventory.api.InventoryContent;
 import com.github.syr0ws.fastinventory.api.InventoryService;
+import com.github.syr0ws.fastinventory.api.action.ClickAction;
+import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.event.FastInventoryClickEvent;
 import com.github.syr0ws.fastinventory.api.item.InventoryItem;
 import org.bukkit.Bukkit;
@@ -20,6 +22,7 @@ import org.bukkit.plugin.Plugin;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public class FastInventoryListener implements Listener {
 
@@ -93,7 +96,10 @@ public class FastInventoryListener implements Listener {
         }
 
         InventoryItem item = itemOptional.get();
-        item.getActions().forEach(action -> action.execute(fastInventoryClickEvent));
+
+        item.getActions().stream()
+                .filter(action -> this.hasClickType(action, event.getClick()))
+                .forEach(action -> action.execute(fastInventoryClickEvent));
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
@@ -170,5 +176,21 @@ public class FastInventoryListener implements Listener {
         Inventory bukkitInventory = fastInventory.getBukkitInventory();
 
         return bukkitInventory.equals(inventory) ? fastInventory : null;
+    }
+
+    private boolean hasClickType(ClickAction action, org.bukkit.event.inventory.ClickType type) {
+
+        Set<ClickType> clickTypes = action.getClickTypes();
+
+        if(clickTypes.contains(ClickType.ALL)) {
+            return true;
+        }
+
+        return switch (type) {
+            case LEFT -> clickTypes.contains(ClickType.LEFT);
+            case RIGHT -> clickTypes.contains(ClickType.RIGHT);
+            case MIDDLE -> clickTypes.contains(ClickType.MIDDLE);
+            default -> false;
+        };
     }
 }


### PR DESCRIPTION
**User story:** As a configurator, I want to differenciate the type of click to execute an action when a player clicks on an item to be able to add different behaviors on a same item.

**Features:**

In the configuration, an action may have the property `click-types` which takes the following values in a list: `LEFT`, `RIGHT`, `MIDDLE`, `ALL`. When the property is not defined, it takes the value `ALL` by default. The `ALL` value is set to handle all types of clicks.

**Examples:**
```yaml
message:
  type: "MESSAGE"
  click-types: 
    - "LEFT"
    - "RIGHT"
  message: "This is a message"
```
```yaml
message:
  type: "MESSAGE"
  message: "This is a message"
```
When a player clicks on the item, only actions which match the type of its click will be executed.

If the `ALL` click type is set in combination with other click types, it overrides them all.