### PR TITLE
feat: improving existing actions player_command, server_command and message

### DIFF
--- a/src/main/java/com/github/syr0ws/fastinventory/common/FastInventoryLibrary.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/FastInventoryLibrary.java
@@ -35,7 +35,7 @@ public class FastInventoryLibrary {
         factory.addLoader(new YamlCloseActionLoader());
         factory.addLoader(new YamlMessageActionLoader());
         factory.addLoader(new YamlPlayerCommandActionLoader());
-        factory.addLoader(new YamlServerCommandActionLoader());
+        factory.addLoader(new YamlConsoleCommandActionLoader());
         factory.addLoader(new YamlPreviousPageActionLoader());
         factory.addLoader(new YamlNextPageActionLoader());
 

--- a/src/main/java/com/github/syr0ws/fastinventory/common/action/CommonMessageAction.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/action/CommonMessageAction.java
@@ -1,0 +1,32 @@
+package com.github.syr0ws.fastinventory.common.action;
+
+import com.github.syr0ws.fastinventory.api.FastInventory;
+import com.github.syr0ws.fastinventory.api.action.ClickType;
+import com.github.syr0ws.fastinventory.api.event.FastInventoryClickEvent;
+import com.github.syr0ws.fastinventory.api.placeholder.PlaceholderManager;
+import com.github.syr0ws.fastinventory.api.provider.InventoryProvider;
+import com.github.syr0ws.fastinventory.api.util.Context;
+
+import java.util.Set;
+
+public abstract class CommonMessageAction extends CommonAction {
+
+    public CommonMessageAction(Set<ClickType> clickTypes) {
+        super(clickTypes);
+    }
+
+    protected String parseMessage(String message, FastInventoryClickEvent event) {
+
+        FastInventory inventory = event.getFastInventory();
+        InventoryProvider provider = inventory.getProvider();
+        PlaceholderManager placeholderManager = provider.getPlaceholderManager();
+
+        Context context = inventory.getDefaultContext();
+
+        String parsed = provider.getI18n()
+                .map(i18n -> i18n.getText(event.getPlayer(), message))
+                .orElse(message);
+
+        return placeholderManager.parse(parsed, context);
+    }
+}

--- a/src/main/java/com/github/syr0ws/fastinventory/common/action/ConsoleCommandAction.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/action/ConsoleCommandAction.java
@@ -12,13 +12,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-public class ServerCommandAction extends CommonAction {
+public class ConsoleCommandAction extends CommonAction {
 
-    public static final String ACTION_NAME = "SERVER_COMMAND";
+    public static final String ACTION_NAME = "CONSOLE_COMMAND";
 
     private final List<String> commands = new ArrayList<>();
 
-    public ServerCommandAction(Set<ClickType> clickTypes, List<String> commands) {
+    public ConsoleCommandAction(Set<ClickType> clickTypes, List<String> commands) {
         super(clickTypes);
 
         if (commands == null || commands.isEmpty()) {

--- a/src/main/java/com/github/syr0ws/fastinventory/common/action/MessageAction.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/action/MessageAction.java
@@ -1,50 +1,42 @@
 package com.github.syr0ws.fastinventory.common.action;
 
-import com.github.syr0ws.fastinventory.api.FastInventory;
 import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.event.FastInventoryClickEvent;
-import com.github.syr0ws.fastinventory.api.placeholder.PlaceholderManager;
-import com.github.syr0ws.fastinventory.api.provider.InventoryProvider;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
-public class MessageAction extends CommonAction {
+public class MessageAction extends CommonMessageAction {
 
     public static final String ACTION_NAME = "MESSAGE";
 
-    private final String message;
+    private final List<String> messages = new ArrayList<>();
 
-    public MessageAction(Set<ClickType> clickTypes, String message) {
+    public MessageAction(Set<ClickType> clickTypes, List<String> messages) {
         super(clickTypes);
 
-        if (message == null) {
+        if (messages == null) {
             throw new IllegalArgumentException("message cannot be null");
         }
 
-        this.message = message;
+        this.messages.addAll(messages);
     }
 
     @Override
     public void execute(FastInventoryClickEvent event) {
 
-        FastInventory inventory = event.getFastInventory();
-        InventoryProvider provider = inventory.getProvider();
-        PlaceholderManager placeholderManager = provider.getPlaceholderManager();
-
-        String message = provider.getI18n()
-                .map(i18n -> i18n.getText(event.getPlayer(), this.message))
-                .orElse(this.message);
-
-        message = placeholderManager.parse(message, inventory.getDefaultContext());
+        String[] messages = this.messages.stream()
+                .map(message -> super.parseMessage(message, event))
+                .toArray(String[]::new);
 
         Player player = event.getPlayer();
-        player.sendMessage(message);
+        player.sendMessage(messages);
     }
 
     @Override
     public String getName() {
         return ACTION_NAME;
     }
-
 }

--- a/src/main/java/com/github/syr0ws/fastinventory/common/action/PlayerCommandAction.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/action/PlayerCommandAction.java
@@ -5,24 +5,27 @@ import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.event.FastInventoryClickEvent;
 import com.github.syr0ws.fastinventory.api.placeholder.PlaceholderManager;
 import com.github.syr0ws.fastinventory.api.provider.InventoryProvider;
+import com.github.syr0ws.fastinventory.api.util.Context;
 import org.bukkit.entity.Player;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 public class PlayerCommandAction extends CommonAction {
 
     public static final String ACTION_NAME = "PLAYER_COMMAND";
 
-    private final String command;
+    private final List<String> commands = new ArrayList<>();
 
-    public PlayerCommandAction(Set<ClickType> clickTypes, String command) {
+    public PlayerCommandAction(Set<ClickType> clickTypes, List<String> commands) {
         super(clickTypes);
 
-        if (command == null || command.isEmpty()) {
-            throw new IllegalArgumentException("command cannot null or empty");
+        if (commands == null || commands.isEmpty()) {
+            throw new IllegalArgumentException("commands cannot null or empty");
         }
 
-        this.command = command;
+        this.commands.addAll(commands);
     }
 
     @Override
@@ -32,10 +35,12 @@ public class PlayerCommandAction extends CommonAction {
         InventoryProvider provider = inventory.getProvider();
         PlaceholderManager placeholderManager = provider.getPlaceholderManager();
 
-        String command = placeholderManager.parse(this.command, inventory.getDefaultContext());
-
+        Context context = inventory.getDefaultContext();
         Player player = event.getPlayer();
-        player.performCommand(command);
+
+        this.commands.stream()
+                .map(command -> placeholderManager.parse(command, context))
+                .forEach(player::performCommand);
     }
 
     @Override

--- a/src/main/java/com/github/syr0ws/fastinventory/common/action/ServerCommandAction.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/common/action/ServerCommandAction.java
@@ -5,24 +5,27 @@ import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.event.FastInventoryClickEvent;
 import com.github.syr0ws.fastinventory.api.placeholder.PlaceholderManager;
 import com.github.syr0ws.fastinventory.api.provider.InventoryProvider;
+import com.github.syr0ws.fastinventory.api.util.Context;
 import org.bukkit.Bukkit;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 public class ServerCommandAction extends CommonAction {
 
     public static final String ACTION_NAME = "SERVER_COMMAND";
 
-    private final String command;
+    private final List<String> commands = new ArrayList<>();
 
-    public ServerCommandAction(Set<ClickType> clickTypes, String command) {
+    public ServerCommandAction(Set<ClickType> clickTypes, List<String> commands) {
         super(clickTypes);
 
-        if (command == null || command.isEmpty()) {
-            throw new IllegalArgumentException("command cannot null or empty");
+        if (commands == null || commands.isEmpty()) {
+            throw new IllegalArgumentException("commands cannot null or empty");
         }
 
-        this.command = command;
+        this.commands.addAll(commands);
     }
 
     @Override
@@ -32,9 +35,11 @@ public class ServerCommandAction extends CommonAction {
         InventoryProvider provider = inventory.getProvider();
         PlaceholderManager placeholderManager = provider.getPlaceholderManager();
 
-        String command = placeholderManager.parse(this.command, inventory.getDefaultContext());
+        Context context = inventory.getDefaultContext();
 
-        Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command);
+        this.commands.stream()
+                .map(command -> placeholderManager.parse(command, context))
+                .forEach(command -> Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command));
     }
 
     @Override

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlCommandActionLoader.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlCommandActionLoader.java
@@ -1,0 +1,23 @@
+package com.github.syr0ws.fastinventory.internal.config.yaml.action;
+
+import com.github.syr0ws.fastinventory.api.config.exception.InventoryConfigException;
+import com.github.syr0ws.fastinventory.common.config.yaml.YamlCommonActionLoader;
+import org.bukkit.configuration.ConfigurationSection;
+
+import java.util.List;
+
+public abstract class YamlCommandActionLoader extends YamlCommonActionLoader {
+
+    private static final String COMMANDS_KEY = "commands";
+
+    protected List<String> loadCommands(ConfigurationSection section) throws InventoryConfigException {
+
+        if (!section.isList(COMMANDS_KEY)) {
+            throw new InventoryConfigException(String.format("Property '%s.%s' not found or is not a list", COMMANDS_KEY, section.getCurrentPath()));
+        }
+
+        return section.getStringList(COMMANDS_KEY).stream()
+                .map(command -> command.startsWith("/") ? command.substring(1) : command)
+                .toList();
+    }
+}

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlConsoleCommandActionLoader.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlConsoleCommandActionLoader.java
@@ -3,14 +3,14 @@ package com.github.syr0ws.fastinventory.internal.config.yaml.action;
 import com.github.syr0ws.fastinventory.api.action.ClickAction;
 import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.config.exception.InventoryConfigException;
-import com.github.syr0ws.fastinventory.common.action.ServerCommandAction;
+import com.github.syr0ws.fastinventory.common.action.ConsoleCommandAction;
 import com.github.syr0ws.fastinventory.common.config.yaml.YamlCommonActionLoader;
 import org.bukkit.configuration.ConfigurationSection;
 
 import java.util.List;
 import java.util.Set;
 
-public class YamlServerCommandActionLoader extends YamlCommonActionLoader {
+public class YamlConsoleCommandActionLoader extends YamlCommonActionLoader {
 
     private static final String COMMANDS_KEY = "commands";
 
@@ -27,11 +27,11 @@ public class YamlServerCommandActionLoader extends YamlCommonActionLoader {
                 .map(command -> command.startsWith("/") ? command.substring(1) : command)
                 .toList();
 
-        return new ServerCommandAction(clickTypes, commands);
+        return new ConsoleCommandAction(clickTypes, commands);
     }
 
     @Override
     public String getName() {
-        return ServerCommandAction.ACTION_NAME;
+        return ConsoleCommandAction.ACTION_NAME;
     }
 }

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlConsoleCommandActionLoader.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlConsoleCommandActionLoader.java
@@ -4,28 +4,18 @@ import com.github.syr0ws.fastinventory.api.action.ClickAction;
 import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.config.exception.InventoryConfigException;
 import com.github.syr0ws.fastinventory.common.action.ConsoleCommandAction;
-import com.github.syr0ws.fastinventory.common.config.yaml.YamlCommonActionLoader;
 import org.bukkit.configuration.ConfigurationSection;
 
 import java.util.List;
 import java.util.Set;
 
-public class YamlConsoleCommandActionLoader extends YamlCommonActionLoader {
-
-    private static final String COMMANDS_KEY = "commands";
+public class YamlConsoleCommandActionLoader extends YamlCommandActionLoader {
 
     @Override
     public ClickAction load(ConfigurationSection section) throws InventoryConfigException {
 
         Set<ClickType> clickTypes = super.loadClickTypes(section);
-
-        if (!section.isList(COMMANDS_KEY)) {
-            throw new InventoryConfigException(String.format("Property '%s.%s' not found or is not a list", COMMANDS_KEY, section.getCurrentPath()));
-        }
-
-        List<String> commands = section.getStringList(COMMANDS_KEY).stream()
-                .map(command -> command.startsWith("/") ? command.substring(1) : command)
-                .toList();
+        List<String> commands = super.loadCommands(section);
 
         return new ConsoleCommandAction(clickTypes, commands);
     }

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlMessageActionLoader.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlMessageActionLoader.java
@@ -7,24 +7,25 @@ import com.github.syr0ws.fastinventory.common.action.MessageAction;
 import com.github.syr0ws.fastinventory.common.config.yaml.YamlCommonActionLoader;
 import org.bukkit.configuration.ConfigurationSection;
 
+import java.util.List;
 import java.util.Set;
 
 public class YamlMessageActionLoader extends YamlCommonActionLoader {
 
-    private static final String MESSAGE_KEY = "message";
+    private static final String MESSAGES_KEY = "messages";
 
     @Override
     public ClickAction load(ConfigurationSection section) throws InventoryConfigException {
 
         Set<ClickType> clickTypes = super.loadClickTypes(section);
 
-        if (!section.isString(MESSAGE_KEY)) {
-            throw new InventoryConfigException(String.format("Property '%s' missing at '%s'", MESSAGE_KEY, section.getCurrentPath()));
+        if (!section.isList(MESSAGES_KEY)) {
+            throw new InventoryConfigException(String.format("Property '%s.%s' not found or is not a list", MESSAGES_KEY, section.getCurrentPath()));
         }
 
-        String message = section.getString(MESSAGE_KEY);
+        List<String> messages = section.getStringList(MESSAGES_KEY);
 
-        return new MessageAction(clickTypes, message);
+        return new MessageAction(clickTypes, messages);
     }
 
     @Override

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlPlayerCommandActionLoader.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlPlayerCommandActionLoader.java
@@ -7,28 +7,27 @@ import com.github.syr0ws.fastinventory.common.action.PlayerCommandAction;
 import com.github.syr0ws.fastinventory.common.config.yaml.YamlCommonActionLoader;
 import org.bukkit.configuration.ConfigurationSection;
 
+import java.util.List;
 import java.util.Set;
 
 public class YamlPlayerCommandActionLoader extends YamlCommonActionLoader {
 
-    private static final String COMMAND_KEY = "command";
+    private static final String COMMANDS_KEY = "commands";
 
     @Override
     public ClickAction load(ConfigurationSection section) throws InventoryConfigException {
 
         Set<ClickType> clickTypes = super.loadClickTypes(section);
 
-        if (!section.isString(COMMAND_KEY)) {
-            throw new InventoryConfigException(String.format("Property '%s' not found or not a string at '%s'", COMMAND_KEY, section.getCurrentPath()));
+        if (!section.isList(COMMANDS_KEY)) {
+            throw new InventoryConfigException(String.format("Property '%s.%s' not found or is not a list", COMMANDS_KEY, section.getCurrentPath()));
         }
 
-        String command = section.getString(COMMAND_KEY);
+        List<String> commands = section.getStringList(COMMANDS_KEY).stream()
+                .map(command -> command.startsWith("/") ? command.substring(1) : command)
+                .toList();
 
-        if (command.startsWith("/")) {
-            command = command.substring(1);
-        }
-
-        return new PlayerCommandAction(clickTypes, command);
+        return new PlayerCommandAction(clickTypes, commands);
     }
 
     @Override

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlPlayerCommandActionLoader.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlPlayerCommandActionLoader.java
@@ -4,28 +4,18 @@ import com.github.syr0ws.fastinventory.api.action.ClickAction;
 import com.github.syr0ws.fastinventory.api.action.ClickType;
 import com.github.syr0ws.fastinventory.api.config.exception.InventoryConfigException;
 import com.github.syr0ws.fastinventory.common.action.PlayerCommandAction;
-import com.github.syr0ws.fastinventory.common.config.yaml.YamlCommonActionLoader;
 import org.bukkit.configuration.ConfigurationSection;
 
 import java.util.List;
 import java.util.Set;
 
-public class YamlPlayerCommandActionLoader extends YamlCommonActionLoader {
-
-    private static final String COMMANDS_KEY = "commands";
+public class YamlPlayerCommandActionLoader extends YamlCommandActionLoader {
 
     @Override
     public ClickAction load(ConfigurationSection section) throws InventoryConfigException {
 
         Set<ClickType> clickTypes = super.loadClickTypes(section);
-
-        if (!section.isList(COMMANDS_KEY)) {
-            throw new InventoryConfigException(String.format("Property '%s.%s' not found or is not a list", COMMANDS_KEY, section.getCurrentPath()));
-        }
-
-        List<String> commands = section.getStringList(COMMANDS_KEY).stream()
-                .map(command -> command.startsWith("/") ? command.substring(1) : command)
-                .toList();
+        List<String> commands = super.loadCommands(section);
 
         return new PlayerCommandAction(clickTypes, commands);
     }

--- a/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlServerCommandActionLoader.java
+++ b/src/main/java/com/github/syr0ws/fastinventory/internal/config/yaml/action/YamlServerCommandActionLoader.java
@@ -7,28 +7,27 @@ import com.github.syr0ws.fastinventory.common.action.ServerCommandAction;
 import com.github.syr0ws.fastinventory.common.config.yaml.YamlCommonActionLoader;
 import org.bukkit.configuration.ConfigurationSection;
 
+import java.util.List;
 import java.util.Set;
 
 public class YamlServerCommandActionLoader extends YamlCommonActionLoader {
 
-    private static final String COMMAND_KEY = "command";
+    private static final String COMMANDS_KEY = "commands";
 
     @Override
     public ClickAction load(ConfigurationSection section) throws InventoryConfigException {
 
         Set<ClickType> clickTypes = super.loadClickTypes(section);
 
-        if (!section.isString(COMMAND_KEY)) {
-            throw new InventoryConfigException(String.format("Property '%s' not found or not a string at '%s'", COMMAND_KEY, section.getCurrentPath()));
+        if (!section.isList(COMMANDS_KEY)) {
+            throw new InventoryConfigException(String.format("Property '%s.%s' not found or is not a list", COMMANDS_KEY, section.getCurrentPath()));
         }
 
-        String command = section.getString(COMMAND_KEY);
+        List<String> commands = section.getStringList(COMMANDS_KEY).stream()
+                .map(command -> command.startsWith("/") ? command.substring(1) : command)
+                .toList();
 
-        if (command.startsWith("/")) {
-            command = command.substring(1);
-        }
-
-        return new ServerCommandAction(clickTypes, command);
+        return new ServerCommandAction(clickTypes, commands);
     }
 
     @Override


### PR DESCRIPTION
**User story:** As a configurator, I want to configure some existing item actions more easily.

**Actions:**

1. Player command

Replacing single command by a list of commands.

```yaml
# Make the player execute a list of commands.
player-command:
  type: "PLAYER_COMMAND"
  # List of commands to execute without slash.
  # Supported placeholders:
  # - %player_name%: Name of the player who executes the action.
  # - %player_uuid%: UUID of the player who executes the action.
  commands: 
    - "command_1"
    - "command 2 arg1"
    - "command 3 arg1 arg2 arg3"
```

2. Console command

Renaming `SERVER_COMMAND` to `CONSOLE_COMMAND` and replacing single command by a list of commands.

```yaml
# Make the console execute a list of commands.
player-command:
  type: "CONSOLE_COMMAND"
  # List of commands to execute without slash.
  # Supported placeholders:
  # - %player_name%: Name of the player who executes the action.
  # - %player_uuid%: UUID of the player who executes the action.
  commands: 
    - "command_1"
    - "command 2 arg1"
    - "command 3 arg1 arg2 arg3"
```

3. Message

Replacing single message by a list of messages.

```yaml
# Send messages to the player.
message:
  type: "MESSAGE"
  # List of messages to send.
  # Features supported:
  # - Placeholders
  # - Color codes prefixed by the character '&' (ex: &e)
  # - Hexadecimal color codes prefixed by the character '#' (ex: #FFFFFF)
  messages: 
    - "message 1"
    - "message 2"
    - "message 3"
```